### PR TITLE
Don't ignore unbound static methods.

### DIFF
--- a/dist/configs/itwinjs-recommended.js
+++ b/dist/configs/itwinjs-recommended.js
@@ -226,7 +226,7 @@ module.exports = {
     "@typescript-eslint/typedef": "off",
     // TODO: We have assignments of unbound methods all over the place.  There's a github issue open to fix this: https://github.com/typescript-eslint/typescript-eslint/issues/1256
     "@typescript-eslint/unbound-method": [
-      "error"
+      "error",
       {
         "ignorestatic": false
       }

--- a/dist/configs/itwinjs-recommended.js
+++ b/dist/configs/itwinjs-recommended.js
@@ -226,9 +226,9 @@ module.exports = {
     "@typescript-eslint/typedef": "off",
     // TODO: We have assignments of unbound methods all over the place.  There's a github issue open to fix this: https://github.com/typescript-eslint/typescript-eslint/issues/1256
     "@typescript-eslint/unbound-method": [
-      "error",
+      "error"
       {
-        "ignoreStatic": true
+        "ignorestatic": false
       }
     ],
     "@typescript-eslint/unified-signatures": "error",


### PR DESCRIPTION
Prevent [mistakes like this](https://github.com/iTwin/itwinjs-core/pull/5409).