### PR TITLE
Clean up unbound-method config

### DIFF
--- a/dist/configs/itwinjs-recommended.js
+++ b/dist/configs/itwinjs-recommended.js
@@ -224,13 +224,7 @@ module.exports = {
     "@typescript-eslint/triple-slash-reference": "error",
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/typedef": "off",
-    // TODO: We have assignments of unbound methods all over the place.  There's a github issue open to fix this: https://github.com/typescript-eslint/typescript-eslint/issues/1256
-    "@typescript-eslint/unbound-method": [
-      "error",
-      {
-        "ignorestatic": false
-      }
-    ],
+    "@typescript-eslint/unbound-method": "error",
     "@typescript-eslint/unified-signatures": "error",
     "arrow-body-style": "off",
     "arrow-parens": "error",


### PR DESCRIPTION
Cleaning up from #15:
- Omit `"ignoreStatic": false` - that's the default.
- Remove obsolete TODO comment.