### PR TITLE
fix beachball publish after introducing duplicate package names via test fixtures

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -18,5 +18,6 @@ module.exports = {
       "pnpm-lock.yaml",
       "tests/fixtures",
     ],
+    package: "@itwin/eslint-plugin",
     changehint: "Run 'pnpm change' to generate a change file",
   };

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -16,8 +16,6 @@ module.exports = {
       ".github/**",
       ".vscode/**",
       "pnpm-lock.yaml",
-      "tests/fixtures",
     ],
-    package: "@itwin/eslint-plugin",
     changehint: "Run 'pnpm change' to generate a change file",
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/eslint-plugin",
-  "version": "4.0.0-dev.39",
+  "version": "4.0.0-dev.40",
   "description": "ESLint plugin with default configuration and custom rules for iTwin.js projects",
   "license": "MIT",
   "keywords": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 packages:
-- "@itwin/eslint-plugin"
+- .

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+- "@itwin/eslint-plugin"


### PR DESCRIPTION
reverts #25, adds correct fix.
Includes a version bump which was done by gh action on this branch