### PR TITLE
Fix extension exports config

### DIFF
--- a/dist/configs/extension-exports-config.js
+++ b/dist/configs/extension-exports-config.js
@@ -6,12 +6,10 @@
 module.exports =
 {
   plugins: {
-    "react-hooks": require("eslint-plugin-react-hooks"),
-    "@typescript-eslint/eslint-plugin": require("@typescript-eslint/eslint-plugin"),
+    "@typescript-eslint": require("@typescript-eslint/eslint-plugin"),
     "import": require("eslint-plugin-import"),
     "prefer-arrow": require("eslint-plugin-prefer-arrow"),
     "deprecation": require("eslint-plugin-deprecation"),
-    "react": require("eslint-plugin-react"),
     "@itwin": require("../plugin")
   },
   languageOptions: require("./utils/language-options"),


### PR DESCRIPTION
Fixed the @typescript-eslint plugin and removed the react plugins as they are not needed. This would help fix the extract-api errors on core and ensure that the extract-extension-api behaves the same way as before. After this PR is merged we would need a new dev version because the core repo is switching over to using the new flat config system. https://github.com/iTwin/itwinjs-core/pull/5731 