### PR TITLE
Fix no-internal to report violations on a per-usage basis

### DIFF
--- a/dist/rules/no-internal.js
+++ b/dist/rules/no-internal.js
@@ -167,32 +167,34 @@ module.exports = {
       for (const jsDoc of declaration.jsDoc) {
         if (jsDoc.tags) {
           for (const tag of jsDoc.tags) {
-            if (bannedTags.includes(tag.tagName.escapedText) && isCheckedFile(declaration)) {
-              //Violation key to track and report violations on a per-usage basis
-              const violationKey = `${declaration.kind}_${declaration.symbol.escapedName}_${tag}_${node.range[0]}`;
-              if (!reportedViolationsSet.has(violationKey)) {
-                reportedViolationsSet.add(violationKey);
-                let name;
-                if (declaration.kind === ts.SyntaxKind.Constructor)
-                  name = declaration.parent.symbol.escapedName;
-                else {
-                  name = declaration.symbol.escapedName;
-                  const parentSymbol = getParentSymbolName(declaration);
-                  if (parentSymbol)
-                    name = `${parentSymbol}.${name}`;
-                }
-
-                context.report({
-                  node,
-                  messageId: "forbidden",
-                  data: {
-                    kind: syntaxKindFriendlyNames.hasOwnProperty(declaration.kind) ? syntaxKindFriendlyNames[declaration.kind] : "unknown object type " + declaration.kind,
-                    name,
-                    tag: tag.tagName.escapedText,
-                  }
-                });
-              }
+            if (!bannedTags.includes(tag.tagName.escapedText) || !isCheckedFile(declaration)) {
+              continue;
             }
+            //Violation key to track and report violations on a per-usage basis
+            const violationKey = `${declaration.kind}_${declaration.symbol.escapedName}_${tag}_${node.range[0]}`;
+            if (reportedViolationsSet.has(violationKey)) {
+              continue;
+            }
+            reportedViolationsSet.add(violationKey);
+            let name;
+            if (declaration.kind === ts.SyntaxKind.Constructor)
+              name = declaration.parent.symbol.escapedName;
+            else {
+              name = declaration.symbol.escapedName;
+              const parentSymbol = getParentSymbolName(declaration);
+              if (parentSymbol)
+                name = `${parentSymbol}.${name}`;
+            }
+
+            context.report({
+              node,
+              messageId: "forbidden",
+              data: {
+                kind: syntaxKindFriendlyNames.hasOwnProperty(declaration.kind) ? syntaxKindFriendlyNames[declaration.kind] : "unknown object type " + declaration.kind,
+                name,
+                tag: tag.tagName.escapedText,
+              }
+            });
           }
         }
       }

--- a/tests/no-internal.js
+++ b/tests/no-internal.js
@@ -78,12 +78,16 @@ ruleTester.run(
           import { internal, public, Internal, Public } from "@itwin/test-pkg-2";
           public();
           internal();
+          internal();
+          internal();
           new Internal();
           new Internal().publicMethod();
           new Public();
           new Public().internalMethod();
         `,
         errors: [
+          { message: 'function "internal" is internal.' },
+          { message: 'function "internal" is internal.' },
           { message: 'function "internal" is internal.' },
           { message: 'class "Internal" is internal.' },
           { message: 'class "Internal" is internal.' },
@@ -96,6 +100,8 @@ ruleTester.run(
           import { internal, public, Internal, Public } from "test-pkg-1";
           public();
           internal();
+          internal();
+          internal();
           new Internal();
           new Internal().publicMethod();
           new Public();
@@ -103,6 +109,8 @@ ruleTester.run(
         `,
         options: [{ "checkedPackagePatterns": ["test-pkg-1"] }],
         errors: [
+          { message: 'function "internal" is internal.' },
+          { message: 'function "internal" is internal.' },
           { message: 'function "internal" is internal.' },
           { message: 'class "Internal" is internal.' },
           { message: 'class "Internal" is internal.' },
@@ -115,6 +123,7 @@ ruleTester.run(
           import { internal, Public } from "workspace-pkg-2";
           internal();
           new Public().internalMethod();
+          new Public().internalMethod();
         `,
         options: [{
           "dontAllowWorkspaceInternal": true,
@@ -122,6 +131,7 @@ ruleTester.run(
         }],
         errors: [
           { message: 'function "internal" is internal.' },
+          { message: 'method "Public.internalMethod" is internal.' },
           { message: 'method "Public.internalMethod" is internal.' }
         ]
       },
@@ -137,55 +147,6 @@ ruleTester.run(
           { message: 'function "internal" is internal.' },
           { message: 'method "Public.internalMethod" is internal.' }
         ]
-      },
-      {
-        // itwin scope with multiple usages
-        code: dedent`
-          import { internal, public } from "@itwin/test-pkg-2";
-          public();
-          internal();
-          internal();
-          internal();
-        `,
-        errors: [
-          { message: 'function "internal" is internal.' },
-          { message: 'function "internal" is internal.' },
-          { message: 'function "internal" is internal.' },
-        ],
-      },
-      {
-        // package name is specified to disallow @internal with multiple usages
-        code: dedent`
-          import { internal, public } from "test-pkg-1";
-          public();
-          internal();
-          internal();
-          internal();
-        `,
-        options: [{ "checkedPackagePatterns": ["test-pkg-1"] }],
-        errors: [
-          { message: 'function "internal" is internal.' },
-          { message: 'function "internal" is internal.' },
-          { message: 'function "internal" is internal.' },
-        ],
-      },
-      {
-        // other package in workspace & package name is specified to disallow @internal with multiple usages
-        code: dedent`
-          import { internal, Public } from "workspace-pkg-2";
-          internal();
-          new Public().internalMethod();
-          new Public().internalMethod();
-        `,
-        options: [{
-          "dontAllowWorkspaceInternal": true,
-          "checkedPackagePatterns": ["workspace-pkg-2"]
-        }],
-        errors: [
-          { message: 'function "internal" is internal.' },
-          { message: 'method "Public.internalMethod" is internal.' },
-          { message: 'method "Public.internalMethod" is internal.' }
-        ],
       },
     ],
   })

--- a/tests/no-internal.js
+++ b/tests/no-internal.js
@@ -137,7 +137,56 @@ ruleTester.run(
           { message: 'function "internal" is internal.' },
           { message: 'method "Public.internalMethod" is internal.' }
         ]
-      }
+      },
+      {
+        // itwin scope with multiple usages
+        code: dedent`
+          import { internal, public } from "@itwin/test-pkg-2";
+          public();
+          internal();
+          internal();
+          internal();
+        `,
+        errors: [
+          { message: 'function "internal" is internal.' },
+          { message: 'function "internal" is internal.' },
+          { message: 'function "internal" is internal.' },
+        ],
+      },
+      {
+        // package name is specified to disallow @internal with multiple usages
+        code: dedent`
+          import { internal, public } from "test-pkg-1";
+          public();
+          internal();
+          internal();
+          internal();
+        `,
+        options: [{ "checkedPackagePatterns": ["test-pkg-1"] }],
+        errors: [
+          { message: 'function "internal" is internal.' },
+          { message: 'function "internal" is internal.' },
+          { message: 'function "internal" is internal.' },
+        ],
+      },
+      {
+        // other package in workspace & package name is specified to disallow @internal with multiple usages
+        code: dedent`
+          import { internal, Public } from "workspace-pkg-2";
+          internal();
+          new Public().internalMethod();
+          new Public().internalMethod();
+        `,
+        options: [{
+          "dontAllowWorkspaceInternal": true,
+          "checkedPackagePatterns": ["workspace-pkg-2"]
+        }],
+        errors: [
+          { message: 'function "internal" is internal.' },
+          { message: 'method "Public.internalMethod" is internal.' },
+          { message: 'method "Public.internalMethod" is internal.' }
+        ],
+      },
     ],
   })
 );


### PR DESCRIPTION
Fixes https://github.com/iTwin/eslint-plugin/issues/37. The problem is that the no-internal rule currently reports only one violation for multiple internal API usages of the same api within a file. Although this is non-critical, it is not ideal behavior. This PR fixes the rule to report violations on a per-usage basis. Added some tests to verify the rule works for multiple usage. 