### PR TITLE
When linting a package, make no-internal not flag usages of internal APIs local to that package

### DIFF
--- a/dist/rules/no-internal.js
+++ b/dist/rules/no-internal.js
@@ -147,7 +147,7 @@ module.exports = {
 
       const isWorkspaceLinkedDependency = !dirContainsPath(parserServices.program.getCommonSourceDirectory(), fileName);
 
-      if (allowWorkspaceInternal && isWorkspaceLinkedDependency)
+      if (allowWorkspaceInternal || !isWorkspaceLinkedDependency)
         return false;
       
       // Else !allowWorkspaceInternal or is a local file, check package name in package.json

--- a/tests/no-internal.js
+++ b/tests/no-internal.js
@@ -37,6 +37,10 @@ ruleTester.run(
     valid: [
       {
         // local import
+        code: `import * as Local from "./local-internal"; Local.internal(); new Local.Internal();`
+      },
+      {
+        // local import and package name is specified
         code: `import * as Local from "./local-internal"; Local.internal(); new Local.Internal();`,
         options: [{ "checkedPackagePatterns": ["workspace-pkg-1"] }],
       },

--- a/tests/no-internal.js
+++ b/tests/no-internal.js
@@ -37,7 +37,8 @@ ruleTester.run(
     valid: [
       {
         // local import
-        code: `import * as Local from "./local-internal"; Local.internal(); new Local.Internal();`
+        code: `import * as Local from "./local-internal"; Local.internal(); new Local.Internal();`,
+        options: [{ "checkedPackagePatterns": ["workspace-pkg-1"] }],
       },
       {
         // not a bentley/itwin scope


### PR DESCRIPTION
Grigas mentioned that the no-internal rule was incorrectly flagging many internal API usages that should be allowed after presentation upgraded to 4.0.0-dev.46 (the version with the new `dontAllowWorkspaceInternal` option). I found that the rule was reporting usages of internal APIs even in some cases in the same file where the API was defined, which is obviously wrong.

This change tweaks the logic so that if `isWorkspaceLinkedDependency == false`, meaning the filename is within the common source directory, aka the file is local to the same package that is being linted, the usage of an internal API is allowed. 

The bug was missed before because the internal API's package name must also match patterns in the `checkedPackagePatterns` option to be flagged, and in the test for local imports the package name didn't match. You can see what I mean by not including this PR's change to the rule, and adding the following test case which should be valid but instead produces errors:
```
{
  code: `import * as Local from "./local-internal"; Local.internal(); new Local.Internal();`,
  options: [{ "checkedPackagePatterns": ["workspace-pkg-1"] }],
}
```