### PR TITLE
add no-node config

### DIFF
--- a/dist/configs/index.js
+++ b/dist/configs/index.js
@@ -2,10 +2,12 @@ const extensionExportsConfig = require("./extension-exports-config");
 const iTwinjsRecommendedConfig = require("./itwinjs-recommended");
 const jsdocConfig = require("./jsdoc");
 const uiConfig = require("./ui");
+const noNodeTypes = require("./no-node");
 
 module.exports = {
     extensionExportsConfig,
     iTwinjsRecommendedConfig,
     jsdocConfig,
-    uiConfig
+    uiConfig,
+    noNodeTypes,
 };

--- a/dist/configs/no-node.js
+++ b/dist/configs/no-node.js
@@ -6,19 +6,10 @@
 module.exports =
 {
   plugins: {
-    "@itwin": require("../plugin")
+    "import": require("eslint-plugin-import"),
   },
   languageOptions: require("./utils/language-options"),
   rules: {
-    "@itwin/public-extension-exports": [
-      "error",
-      {
-        "releaseTags": [
-          "public",
-          "preview"
-        ],
-        "outputApiFile": true
-      }
-    ]
+    "import/no-nodejs-modules": "error",
   }
 }


### PR DESCRIPTION
https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-nodejs-modules.md

Another optional config that would enrich the recommended config for browser-compatible packages