### PR TITLE
Rename conflicting test package names

### DIFF
--- a/tests/fixtures/no-internal/workspace-pkg-1/node_modules/test-pkg-1/package.json
+++ b/tests/fixtures/no-internal/workspace-pkg-1/node_modules/test-pkg-1/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "test-pkg-1",
+  "name": "test-pkg-1-no-internal",
   "version": "1.0.0",
-  "description": "test package 1",
+  "description": "test package 1 no internal",
   "main": "index.js",
   "typings": "index.d.ts",
   "license": "MIT"


### PR DESCRIPTION
Since the removal of `pnpm-workspace.yml`, the version bump script seems to work differently. Consequently, two of the test package's names conflict and prevent from pkg version bump and pkg publication: https://github.com/iTwin/eslint-plugin/actions/runs/7802958591/job/21281612011

This PR is to fix that issue