### PR TITLE
Manually set pkg version to 4.0.0-dev.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/eslint-plugin",
-  "version": "4.0.0-dev.49",
+  "version": "4.0.0-dev.50",
   "description": "ESLint plugin with default configuration and custom rules for iTwin.js projects",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Manually set pkg version to 4.0.0-dev.50 since git pre-commit failed in pipeline: https://github.com/iTwin/eslint-plugin/actions/runs/7805630292/job/21290249430 even though the publish of the pkg was successful: https://www.npmjs.com/package/@itwin/eslint-plugin/v/4.0.0-dev.50