### PR TITLE
Disable some of the newer lint rules

### DIFF
--- a/change/@itwin-eslint-plugin-4fa567f9-7cb3-4b10-a1fe-19c169ea596a.json
+++ b/change/@itwin-eslint-plugin-4fa567f9-7cb3-4b10-a1fe-19c169ea596a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable some of the newer lint rules.",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "33036725+wgoehrig@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/dist/configs/itwinjs-recommended.js
+++ b/dist/configs/itwinjs-recommended.js
@@ -121,7 +121,7 @@ module.exports =
         "leadingUnderscore": "forbid"
       },
       {
-        "selector": "enumMember",
+        "selector": ["enumMember", "import"],
         "format": null,
         "leadingUnderscore": "allow"
       },
@@ -170,12 +170,14 @@ module.exports =
       }
     ],
     "@typescript-eslint/return-await": "error",
+    "@typescript-eslint/no-duplicate-type-constituents": "off",
     "@typescript-eslint/no-this-alias": "error",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-enum-comparison": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/no-unsafe-return": "off",
     "@typescript-eslint/no-unused-vars": [

--- a/dist/configs/itwinjs-recommended.js
+++ b/dist/configs/itwinjs-recommended.js
@@ -177,7 +177,7 @@ module.exports =
     "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-unsafe-call": "off",
-    "@typescript-eslint/no-unsafe-enum-comparison": "off",
+    "@typescript-eslint/no-unsafe-enum-comparison": "error",
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/no-unsafe-return": "off",
     "@typescript-eslint/no-unused-vars": [


### PR DESCRIPTION
Specifically `no-duplicate-type-constituents`, which does not play well with aliases like `Id64String`, and `no-unsafe-enum-comparison`, which seems unnecessary.

Also, IMO, the new strict enforcement of naming conventions for default and namespace imports is not super helpful either.