### PR TITLE
Manually set pkg version to 4.0.0-dev.51

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/eslint-plugin",
-  "version": "4.0.0-dev.50",
+  "version": "4.0.0-dev.51",
   "description": "ESLint plugin with default configuration and custom rules for iTwin.js projects",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Previously attempted fix did not seem to have worked: https://github.com/iTwin/eslint-plugin/actions/runs/7919189086

Package was published however: https://www.npmjs.com/package/@itwin/eslint-plugin/v/4.0.0-dev.51

Further investigation required to fix issue

Issue created: https://github.com/iTwin/eslint-plugin/issues/60