### PR TITLE
Fix git pre-commit action failure

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -35,5 +35,5 @@ jobs:
 
       - name: Git Commit action
         run: |
-          git commit -m "Version bump (skip actions)"
+          git commit -m "Version bump -- skip actions"
         

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -35,5 +35,5 @@ jobs:
 
       - name: Git Commit action
         run: |
-          git commit -m "Version bump -- skip actions"
+          git commit -m "Version bump [skip actions]"
         

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -35,5 +35,5 @@ jobs:
 
       - name: Git Commit action
         run: |
-          git commit -m "Version bump [skip actions]"
+          git commit -m "Version bump (skip actions)"
         

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -19,7 +19,7 @@ jobs:
       
       - name: Configure git
         run: |
-          git config --local user.email imodeljs-admin@users.noreply.github.com
+          git config --local user.email 38288322+imodeljs-admin@users.noreply.github.com
           git config --local user.name imodeljs-admin 
 
       - name: Install pnpm

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -35,5 +35,5 @@ jobs:
 
       - name: Git Commit action
         run: |
-          git commit -m Version bump [skip actions]
+          git commit -m "Version bump [skip actions]""
         

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Tests
         run: pnpm run cover
 
-      - name: Publish packages
+      - name: Git Commit action
         run: |
           git commit -m Version bump [skip actions]
         

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -32,6 +32,11 @@ jobs:
 
       - name: Run Tests
         run: pnpm run cover
+      
+      - name: Dummy add
+        run: |
+          git checkout main package.json
+          git add .
 
       - name: Git Commit action
         run: |

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -35,7 +35,7 @@ jobs:
       
       - name: Dummy add
         run: |
-          git checkout main package.json
+          echo "tester" > tester.txt
           git add .
 
       - name: Git Commit action

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -35,5 +35,5 @@ jobs:
 
       - name: Git Commit action
         run: |
-          git commit -m "Version bump [skip actions]""
+          git commit -m "Version bump [skip actions]"
         

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -35,7 +35,5 @@ jobs:
 
       - name: Publish packages
         run: |
-          pnpm publish-packages-dev -y --branch ${{ github.ref_name }} --message "Version bump [skip actions]"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
-
+          git commit -m Version bump [skip actions]
+        

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -19,7 +19,7 @@ jobs:
       
       - name: Configure git
         run: |
-          git config --local user.email 38288322+imodeljs-admin@users.noreply.github.com
+          git config --local user.email imodeljs-admin@users.noreply.github.com
           git config --local user.name imodeljs-admin 
 
       - name: Install pnpm

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -32,13 +32,9 @@ jobs:
 
       - name: Run Tests
         run: pnpm run cover
-      
-      - name: Dummy add
-        run: |
-          echo "tester" > tester.txt
-          git add .
 
-      - name: Git Commit action
+      - name: Publish packages
         run: |
-          git commit -m "Version bump [skip actions]"
-        
+          pnpm publish-packages-dev -y --branch ${{ github.ref_name }} --message "Version bump [skip actions]"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # validate email
 emailPattern="[^@]+@users\\.noreply\\.github\\.com"
 email=$(git config user.email)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,10 @@
 emailPattern="[^@]+@users\\.noreply\\.github\\.com"
 email=$(git config user.email)
 
-if ! [[ "$email" =~ $emailPattern ]]; then
+if [[ "$email" =~ $emailPattern ]]; then
+  echo "User email is configured correctly"
+  exit 0;
+else
   echo "Git commits should be using an e-mail like this pattern: \"$emailPattern\""
   echo "But yours is configured like this: $email"
   echo "To fix it, you can use command like this:"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,10 @@
+#!/bin/bash
+
 # validate email
 emailPattern="[^@]+@users\\.noreply\\.github\\.com"
 email=$(git config user.email)
 
-if [[ "$email" =~ $emailPattern ]]; then
-  echo "User email is configured correctly"
-  exit 0;
-else
+if ! [[ $email =~ $emailPattern ]]; then
   echo "Git commits should be using an e-mail like this pattern: \"$emailPattern\""
   echo "But yours is configured like this: $email"
   echo "To fix it, you can use command like this:"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,8 @@
-#!/bin/bash
-
 # validate email
 emailPattern="[^@]+@users\\.noreply\\.github\\.com"
 email=$(git config user.email)
 
-if ! [[ $email =~ $emailPattern ]]; then
+if echo "$email" | grep -qvE "$emailPattern"; then
   echo "Git commits should be using an e-mail like this pattern: \"$emailPattern\""
   echo "But yours is configured like this: $email"
   echo "To fix it, you can use command like this:"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 emailPattern="[^@]+@users\\.noreply\\.github\\.com"
 email=$(git config user.email)
 
-if ! [[ $email =~ $emailPattern ]]; then
+if ! [[ "$email" =~ $emailPattern ]]; then
   echo "Git commits should be using an e-mail like this pattern: \"$emailPattern\""
   echo "But yours is configured like this: $email"
   echo "To fix it, you can use command like this:"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "version-bump-dev": "beachball bump --config beachball.config.dev.js --keep-change-files",
     "publish-packages": "beachball publish",
     "publish-packages-dev": "beachball publish --config beachball.config.dev.js --keep-change-files",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "author": {
     "name": "Bentley Systems, Inc.",
@@ -56,7 +56,7 @@
     "@types/node": "20.11.16",
     "beachball": "^2.39.0",
     "eslint": "^8.56.0",
-    "husky": "^9.0.5",
+    "husky": "^9.0.11",
     "mocha": "^10.2.0",
     "typescript": "~5.3.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ devDependencies:
     specifier: ^8.56.0
     version: 8.56.0
   husky:
-    specifier: ^9.0.5
-    version: 9.0.5
+    specifier: ^9.0.11
+    version: 9.0.11
   mocha:
     specifier: ^10.2.0
     version: 10.2.0
@@ -1420,8 +1420,8 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
-  /husky@9.0.5:
-    resolution: {integrity: sha512-/EX48XLor4FczjgdJjwK4qMETrJxJqF4rkgo+NUeK8b2F4TV6s5QxAuG2JZfxm4b9WnrgBGS7bA/JK+H5CKg+A==}
+  /husky@9.0.11:
+    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
     engines: {node: '>=18'}
     hasBin: true
     dev: true


### PR DESCRIPTION
The the reason for this failure was in https://github.com/iTwin/eslint-plugin/pull/51, husky was upgraded to v9. The way husky executes shell scripts is different in v9. It always uses `sh` instead of `bash`: https://github.com/typicode/husky/releases/tag/v9.0.1
<img width="483" alt="image" src="https://github.com/iTwin/eslint-plugin/assets/98850418/a03a4c48-be17-45c4-a467-5764bee1ce62">
`[[` operator is a bash feature and is not available on regular shell: https://stackoverflow.com/questions/3401183/bash-syntax-error-not-found Hence, previously this was not failing because `bash` was being used but now it is failing because `sh` is being used after the husky upgrade. So, the shell script needs to use `grep` instead of `[[]]` now for it to work properly.

Working example: https://github.com/iTwin/eslint-plugin/actions/runs/7937037057/job/21673467158