### PR TITLE
Fix CSV creation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,4 @@
 # review when someone opens a pull request.
 
 # Assign ownership of the entire repository to
-* @paulius-valiunas @MichaelBelousov @ben-polinsky @aruniverse
-
-
+* @paulius-valiunas @ben-polinsky @aruniverse @anmolshres98

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ package-lock.json
 
 # Mac specfic
 **/.DS_Store
+
+# tests - when testing for csv output, we write the actual file because we cannot mock in eslint tests
+lib/*.csv

--- a/change/@itwin-eslint-plugin-bb1fb98c-b50a-4871-b228-aa0aad43691e.json
+++ b/change/@itwin-eslint-plugin-bb1fb98c-b50a-4871-b228-aa0aad43691e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix csv output generation",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "ben-polinsky@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/dist/rules/no-internal-barrel-imports.js
+++ b/dist/rules/no-internal-barrel-imports.js
@@ -156,7 +156,7 @@ const rule = {
             program.getResolvedModule(
               sourceFile,
               moduleSpecifierText
-            ).resolvedModule;
+            )?.resolvedModule;
         }
 
         if (typeof node.source.value !== "string")

--- a/dist/rules/public-extension-exports.js
+++ b/dist/rules/public-extension-exports.js
@@ -86,16 +86,12 @@ module.exports = {
       }
     }
 
-    function addToApiList(declaration, tags) {
+    function addToApiList(declaration) {
       if (!outputApiFile) {
         return;
       }
-      const validReleaseTag = tags.find((tag) =>
-        releaseTags.includes(tag.tagName.escapedText)
-      );
 
-      const createCsvString = (name, kind) =>
-        `${name},${kind},${validReleaseTag}\n`;
+      const createCsvString = (name, kind) => `${name},${kind},Public\n`;
 
       const names =
         declaration.kind === ts.SyntaxKind.VariableStatement
@@ -184,12 +180,13 @@ module.exports = {
       };
 
       if (hasExtensionTag) {
-        addToApiList(declaration, tags);
-        if (!hasPublicTag)
+        if (!hasPublicTag) {
           context.report({
             ...commonReport,
             messageId: "missingExtensionReleaseTag",
           });
+        }
+        addToApiList(declaration);
         return true;
       }
       return false;

--- a/tests/public-extension-exports.js
+++ b/tests/public-extension-exports.js
@@ -91,6 +91,22 @@ tester.run("public-extension-exports", PublicExtensionsExports, {
         }
         `,
     },
+    /**
+     * CSV Output:
+     * NOTE: There's not a great way to test this programmatically from within the eslint test runner.
+     * Please check that the lib/GeneratedExtensionApi.csv file is created and contains the expected data after your test runs.
+     */
+    {
+      code: `
+        /**
+         * @extensions
+         * @public
+         */
+        export function destroyAllIModels(): void{
+        }
+        `,
+      options: [{ outputApiFile: true }],
+    },
   ],
   invalid: [
     // extensions require public tag.


### PR DESCRIPTION
Fix CSV creation - since we are currently (under discussion) allowing only public APIs to be extension APIs, that is now hard coded. 

Add basic CSV creation test. 

Also, fixes an issue:
`program.getResolvedModule` can return undefined, but we were not expecting that possibility.