### PR TITLE
Add new formatter for no-internal rule violations that creates summary tables and csv report

### DIFF
--- a/dist/formatters/no-internal-summary-table-creator.js
+++ b/dist/formatters/no-internal-summary-table-creator.js
@@ -46,9 +46,7 @@ module.exports = function(messages, ruleId) {
     const re = new RegExp('(.*) "(.*)" is (.*).');
     const match = errorMessage.match(re);
     if (match) {
-      const kind = match[1];
-      const name = match[2];
-      const tag = match[3];
+    const [, kind, name, tag] = match
       const filePath = message.location?.file ?? message.filePath;
       const relativeFilePath = filePath.replace(cwdWithSeparator, '');
       const problemFileMapKey = `${relativeFilePath};;${tag}`;

--- a/dist/formatters/no-internal-summary-table-creator.js
+++ b/dist/formatters/no-internal-summary-table-creator.js
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+const path = require('path');
+const fs = require('fs');
+
+module.exports = function(messages, ruleId) {
+  const problemFiles = new Map();
+  const errorTracker = new Map();
+  const tagViolationsTracker = new Map();
+  const currentWorkingDirectory = process.cwd();
+  const maxCellWidth = 80;
+  // Ensure the current working directory ends with a path separator
+  const cwdWithSeparator = currentWorkingDirectory.endsWith(path.sep) ? currentWorkingDirectory : currentWorkingDirectory + path.sep;
+
+  function createAsciiTable(rows, maxCellWidth) {
+    // Calculate column widths
+    const colWidths = rows[0].map((_, i) => Math.min(Math.max(...rows.map(row => String(row[i]).length)), maxCellWidth));
+
+    // Create row separator
+    const rowSeparator = '+' + colWidths.map(width => '-'.repeat(width + 2)).join('+') + '+';
+
+    // Split cell contents into lines
+    const splitRows = rows.map(row => row.map((cell, i) => {
+        const cellStr = String(cell);
+        const lines = [];
+        for (let j = 0; j < cellStr.length; j += maxCellWidth) {
+            lines.push(cellStr.slice(j, j + maxCellWidth));
+        }
+        return lines;
+    }));
+
+    // Convert rows to strings
+    const rowStrings = splitRows.map(row => {
+        const numLines = Math.max(...row.map(cellLines => cellLines.length));
+        const lines = Array(numLines).fill().map((_, i) =>
+            '|' + row.map((cellLines, j) => ' ' + (cellLines[i] || '').padEnd(colWidths[j]) + ' ').join('|') + '|'
+        );
+        return lines.join('\n');
+    });
+
+    // Join everything together
+    return rowSeparator + '\n' + rowStrings.join('\n' + rowSeparator + '\n') + '\n' + rowSeparator;
+}
+
+  messages.forEach((message) => {
+    const errorMessage = message.text ?? message.message;
+    // regex pattern for error message for no internal violations
+    const re = new RegExp('(.*) "(.*)" is (.*).');
+    const match = errorMessage.match(re);
+    if (match) {
+      const kind = match[1];
+      const name = match[2];
+      const tag = match[3];
+      const filePath = message.location?.file ?? message.filePath;
+      const relativeFilePath = filePath.replace(cwdWithSeparator, '');
+      const fileDetails = problemFiles.get(relativeFilePath) ?? { locations: "", tags: "" };
+      const newLocations = fileDetails.locations + `${message.location?.line ?? message.line}:${message.location?.column ?? message.column},`;
+      const newTags = fileDetails.tags.includes(tag) ? fileDetails.tags : fileDetails.tags + `${tag},`;
+      problemFiles.set(relativeFilePath, { locations: newLocations, tags: newTags });
+
+      const key = `${kind};;${name};;${tag}`;
+      const currentCount = errorTracker.get(key) ?? 0;
+      const newCount = currentCount + 1;
+      errorTracker.set(key, newCount);
+
+      const tagViolationCount = tagViolationsTracker.get(tag) ?? 0;
+      tagViolationsTracker.set(tag, tagViolationCount + 1);
+    }
+  });
+
+    if (problemFiles.size === 0 || errorTracker.size === 0)
+      return;
+
+    // iterate over the problemFiles and for each value, remove the last comma from locations and tags fileds
+    for (const [key, value] of problemFiles.entries()) {
+      const locations = value.locations.slice(0, -1);
+      const tags = value.tags.slice(0, -1);
+      problemFiles.set(key, { locations, tags });
+    }
+
+    const filesSummaryRows = [
+      ['File', 'Locations', 'Tags'],
+      ...Array.from(problemFiles.entries()).map(([filePath, { locations, tags }]) => [filePath, locations, tags]),
+    ];
+    const filesSummaryTable = createAsciiTable(filesSummaryRows, maxCellWidth);
+
+    const rows = [
+      ["Kind and Name", "Tag", "# of Occurrences"],
+      ...Array.from(errorTracker.entries()).map(([key, value]) => {
+        const [kind, name, tag] = key.split(";;");
+        return [`${kind} ${name}`, tag, value];
+      })
+
+    ];
+    const summaryTable = createAsciiTable(rows, maxCellWidth);
+
+    const tagViolationsRows = [
+      ["Tag", "# of Occurrences"],
+      ...Array.from(tagViolationsTracker.entries()).map(([tag, value]) => [tag, value]),
+    ];
+    const tagViolationsTable = createAsciiTable(tagViolationsRows, maxCellWidth);
+    // create a csv of the 2D arrays problemFiles and errorTracker and save that csv file in the current working directory
+    // Convert 2D arrays to CSV format
+    const problemFilesCSV = Array.from(problemFiles.entries()).map(([filePath, { locations, tags }]) => `${filePath},"${locations}","${tags}"`).join('\n');
+    const errorTrackerCSV = Array.from(errorTracker.entries()).map(([key, value]) => {
+      const [kind, name, tag] = key.split(";;");
+      return `${kind} ${name},${tag},${value}`;
+    }).join('\n');
+    const tagViolationsCSV = Array.from(tagViolationsTracker.entries()).map(([tag, value]) => `${tag},${value}`).join('\n');
+
+    const allTablesSummaryTitle = `Summary tables for '${ruleId}' lint rule violations:`;
+    const problemFilesTitle = `'${ruleId}' violations summary table by kind and name:`;
+    const errorTrackerTitle = `'${ruleId}' violations summary table by files:`;
+    const tagViolationsTitle = `'${ruleId}' violations summary table by tags:`;
+
+    // Combine problemFilesCSV and errorTrackerCSV
+    const combinedCSV = `${allTablesSummaryTitle}\n\n${errorTrackerTitle}\nKind and Name,Tag,# of Occurrences\n${errorTrackerCSV}\n\n${problemFilesTitle}\nFile,Locations,Tags\n${problemFilesCSV}\n\n${tagViolationsTitle}\nTag,# of Occurrences\n${tagViolationsCSV}\n`;
+
+    // Save the CSV file in the current working directory
+    fs.writeFileSync('no-internal-summary.csv', combinedCSV);
+
+    return `${allTablesSummaryTitle}\n${errorTrackerTitle}\n${summaryTable}\n${problemFilesTitle}\n${filesSummaryTable}\n${tagViolationsTitle}\n${tagViolationsTable}\n`;
+};

--- a/dist/formatters/no-internal-summary-with-table.js
+++ b/dist/formatters/no-internal-summary-with-table.js
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 "use strict";
 
-const tableCreator = require('./no-internal-summary-table-creator');
+const tableCreator = require('./utils/no-internal-summary-table-creator');
 
 module.exports = function (results) {
   const noInternalRuleId = '@itwin/no-internal';

--- a/dist/formatters/no-internal-summary-with-table.js
+++ b/dist/formatters/no-internal-summary-with-table.js
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+"use strict";
+
+const tableCreator = require('./no-internal-summary-table-creator');
+
+module.exports = function (results) {
+  const noInternalRuleId = '@itwin/no-internal';
+  const filteredMessages = results.flatMap(result =>
+    result.messages
+      .filter(message => message.ruleId === noInternalRuleId)
+      .map(message => ({ ...message, filePath: result.filePath }))
+  );
+  return tableCreator(filteredMessages, noInternalRuleId);
+};

--- a/dist/formatters/utils/create-ascii-table.js
+++ b/dist/formatters/utils/create-ascii-table.js
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+function createAsciiTable(rows, maxCellWidth) {
+  // Calculate column widths
+  const colWidths = rows[0].map((_, i) => Math.min(Math.max(...rows.map(row => String(row[i]).length)), maxCellWidth));
+
+  // Create row separator
+  const rowSeparator = '+' + colWidths.map(width => '-'.repeat(width + 2)).join('+') + '+';
+
+  // Split cell contents into lines
+  const splitRows = rows.map(row => row.map((cell, i) => {
+      const cellStr = String(cell);
+      const lines = [];
+      for (let j = 0; j < cellStr.length; j += maxCellWidth) {
+          lines.push(cellStr.slice(j, j + maxCellWidth));
+      }
+      return lines;
+  }));
+
+  // Convert rows to strings
+  const rowStrings = splitRows.map(row => {
+      const numLines = Math.max(...row.map(cellLines => cellLines.length));
+      const lines = Array(numLines).fill().map((_, i) =>
+          '|' + row.map((cellLines, j) => ' ' + (cellLines[i] || '').padEnd(colWidths[j]) + ' ').join('|') + '|'
+      );
+      return lines.join('\n');
+  });
+
+  // Join everything together
+  return rowSeparator + '\n' + rowStrings.join('\n' + rowSeparator + '\n') + '\n' + rowSeparator;
+}
+
+module.exports = createAsciiTable;

--- a/dist/formatters/utils/no-internal-summary-table-creator.js
+++ b/dist/formatters/utils/no-internal-summary-table-creator.js
@@ -18,11 +18,12 @@ module.exports = function(messages, ruleId) {
 
   messages.forEach((message) => {
     const errorMessage = message.text ?? message.message;
-    // regex pattern for error message for no internal violations
-    const re = new RegExp('(.*) "(.*)" is (.*).');
-    const match = errorMessage.match(re);
-    if (match) {
-      const [, kind, name, tag] = match;
+    // parse the kind, name, and tag from the error message without using a regex pattern
+      const messageSplit = errorMessage.split(' is ');
+      const tag = messageSplit[1].replace('.', '');
+      const secondMessageSplit = messageSplit[0].split(' ');
+      const kind = secondMessageSplit[0];
+      const name = secondMessageSplit[1].replace(/"/g, '');
       const filePath = message.location?.file ?? message.filePath;
       const relativeFilePath = filePath.replace(cwdWithSeparator, '');
       const problemFileMapKey = `${relativeFilePath};;${tag}`;
@@ -37,7 +38,6 @@ module.exports = function(messages, ruleId) {
 
       const tagViolationCount = tagViolationsTracker.get(tag) ?? 0;
       tagViolationsTracker.set(tag, tagViolationCount + 1);
-    }
   });
 
     if (problemFiles.size === 0 || errorTracker.size === 0 || tagViolationsTracker.size === 0)
@@ -91,7 +91,7 @@ module.exports = function(messages, ruleId) {
     const tagViolationsTitle = `'${ruleId}' violations summary table by tags:`;
 
     // Combine problemFilesCSV and errorTrackerCSV
-    const combinedCSV = `${allTablesSummaryTitle}\n\n${errorTrackerTitle}\nKind and Name,Tag,# of Occurrences\n${errorTrackerCSV}\n\n${problemFilesTitle}\nFile,Locations,Tags\n${problemFilesCSV}\n\n${tagViolationsTitle}\nTag,# of Occurrences\n${tagViolationsCSV}\n`;
+    const combinedCSV = `${allTablesSummaryTitle}\n\n${errorTrackerTitle}\nKind and Name,Tag,# of Occurrences\n${errorTrackerCSV}\n\n${problemFilesTitle}\nFile,Locations,Tag,# of Occurrences\n${problemFilesCSV}\n\n${tagViolationsTitle}\nTag,# of Occurrences\n${tagViolationsCSV}\n`;
 
     // Save the CSV file in the current working directory
     fs.writeFileSync('no-internal-summary.csv', combinedCSV);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,8 +4,10 @@
 *--------------------------------------------------------------------------------------------*/
 const plugin = require("./plugin");
 const configs = require("./configs");
+const noInternalSummaryTableCreator = require("./formatters/no-internal-summary-table-creator");
 
 module.exports = {
   configs,
+  noInternalSummaryTableCreator,
   ...plugin
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 const plugin = require("./plugin");
 const configs = require("./configs");
-const noInternalSummaryTableCreator = require("./formatters/no-internal-summary-table-creator");
+const noInternalSummaryTableCreator = require("./formatters/utils/no-internal-summary-table-creator");
 
 module.exports = {
   configs,


### PR DESCRIPTION
Create summary table of the no-internal rule violations, preserve default behavior so this formatting would be opt-in and need to be explicitly called.

Also creates a csv with the same table as a report in the current working directory.

**Before:**
![image](https://github.com/iTwin/eslint-plugin/assets/98850418/093b92ad-0f40-4a85-ac11-9bb5908325f8)
**After:**
![image](https://github.com/iTwin/eslint-plugin/assets/98850418/d59fbf06-678d-43f7-b21b-fbc74edf3641)
![image](https://github.com/iTwin/eslint-plugin/assets/98850418/426aba67-7998-4daf-acdc-d7dd9e56d8a1)
![image](https://github.com/iTwin/eslint-plugin/assets/98850418/62e73388-fb62-4edb-b7c3-ca9cfab4e984)


csv report file generated with the same table:
![image](https://github.com/iTwin/eslint-plugin/assets/98850418/288cf2e4-5f0f-4a06-9a7f-3094bf59b71d)
