### PR TITLE
Add optional parameter for creating CSV in no-internal-summary-table-creator.js

### DIFF
--- a/change/@itwin-eslint-plugin-c30c7811-70ff-4ef7-b4f9-21ae34ef5fa0.json
+++ b/change/@itwin-eslint-plugin-c30c7811-70ff-4ef7-b4f9-21ae34ef5fa0.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add optional parameter for creating CSV in no-internal-summary-table-creator.js",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "anmolshres98@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/dist/formatters/utils/no-internal-summary-table-creator.js
+++ b/dist/formatters/utils/no-internal-summary-table-creator.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const process = require('process');
 const createAsciiTable = require('./create-ascii-table');
 
-module.exports = function(messages, ruleId) {
+module.exports = function(messages, ruleId, createCSV = true) {
   const problemFiles = new Map();
   const errorTracker = new Map();
   const tagViolationsTracker = new Map();
@@ -94,7 +94,8 @@ module.exports = function(messages, ruleId) {
     const combinedCSV = `${allTablesSummaryTitle}\n\n${errorTrackerTitle}\nKind and Name,Tag,# of Occurrences\n${errorTrackerCSV}\n\n${problemFilesTitle}\nFile,Locations,Tag,# of Occurrences\n${problemFilesCSV}\n\n${tagViolationsTitle}\nTag,# of Occurrences\n${tagViolationsCSV}\n`;
 
     // Save the CSV file in the current working directory
-    fs.writeFileSync('no-internal-summary.csv', combinedCSV);
+    if (createCSV)
+      fs.writeFileSync('no-internal-summary.csv', combinedCSV);
 
     return `${allTablesSummaryTitle}\n${errorTrackerTitle}\n${summaryTable}\n${problemFilesTitle}\n${filesSummaryTable}\n${tagViolationsTitle}\n${tagViolationsTable}\n`;
 };


### PR DESCRIPTION
This pull request adds an optional parameter to the `no-internal-summary-table-creator.js` file, allowing the user to choose whether or not to create a CSV file. 

The default behavior is still that the csv file is generated since that behavior currently exists in the released version of plugin. If any downstream apps rely on the existence of the csv file than that would make it a breaking change if we disabled the csv creation by default.