### PR TITLE
Add JSDoc for the summary table creator function

### DIFF
--- a/change/@itwin-eslint-plugin-36c0901a-a809-44e8-973b-347ebf6a80bb.json
+++ b/change/@itwin-eslint-plugin-36c0901a-a809-44e8-973b-347ebf6a80bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add JSDoc for the summary table creator function",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "anmolshres98@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@itwin-eslint-plugin-36c0901a-a809-44e8-973b-347ebf6a80bb.json
+++ b/change/@itwin-eslint-plugin-36c0901a-a809-44e8-973b-347ebf6a80bb.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add JSDoc for the summary table creator function",
-  "packageName": "@itwin/eslint-plugin",
-  "email": "anmolshres98@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@itwin-eslint-plugin-79533bb2-3593-49c1-8fbe-fdbaf887e839.json
+++ b/change/@itwin-eslint-plugin-79533bb2-3593-49c1-8fbe-fdbaf887e839.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't create csv report by default and add JSDoc for the summary table creator function",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "anmolshres98@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/dist/formatters/utils/no-internal-summary-table-creator.js
+++ b/dist/formatters/utils/no-internal-summary-table-creator.js
@@ -7,6 +7,21 @@ const fs = require('fs');
 const process = require('process');
 const createAsciiTable = require('./create-ascii-table');
 
+/**
+ * Generates a summary table and optionally a CSV from linting messages for a specific rule.
+ * 
+ * This function processes an array of linting messages, filters them by a specified rule ID,
+ * and then generates a summary table and optionally a CSV file based on these messages. 
+ * 
+ * The summary table is always created and returned while the CSV file is created only if the 
+ * `createCSV` flag is set to `true`.
+ * 
+ * @param {Object[]} messages - An array of linting message objects to be processed.
+ * @param {string} ruleId - The ID of the linting rule to filter messages by.
+ * @param {boolean} [createCSV=true] - A boolean flag indicating whether to create a CSV file (`true`) 
+ *                                     or not. Defaults to `true`.
+ * @returns {string} The generated summary table as a string.
+ */
 module.exports = function(messages, ruleId, createCSV = true) {
   const problemFiles = new Map();
   const errorTracker = new Map();
@@ -41,7 +56,7 @@ module.exports = function(messages, ruleId, createCSV = true) {
   });
 
     if (problemFiles.size === 0 || errorTracker.size === 0 || tagViolationsTracker.size === 0)
-      return;
+      return '';
 
     // iterate over the problemFiles and for each value, remove the last comma from locations
     for (const [key, value] of problemFiles.entries()) {

--- a/dist/formatters/utils/no-internal-summary-table-creator.js
+++ b/dist/formatters/utils/no-internal-summary-table-creator.js
@@ -18,11 +18,11 @@ const createAsciiTable = require('./create-ascii-table');
  * 
  * @param {Object[]} messages - An array of linting message objects to be processed.
  * @param {string} ruleId - The ID of the linting rule to filter messages by.
- * @param {boolean} [createCSV=true] - A boolean flag indicating whether to create a CSV file (`true`) 
- *                                     or not. Defaults to `true`.
+ * @param {boolean} [createCSV=false] - A boolean flag indicating whether to create a CSV file (`true`) 
+ *                                     or not. Defaults to `false`.
  * @returns {string} The generated summary table as a string.
  */
-module.exports = function(messages, ruleId, createCSV = true) {
+module.exports = function(messages, ruleId, createCSV = false) {
   const problemFiles = new Map();
   const errorTracker = new Map();
   const tagViolationsTracker = new Map();


### PR DESCRIPTION
This pull request adds JSDoc comments to the summary table creator function. The function generates a summary table and optionally a CSV file from linting messages for a specific rule. The JSDoc comments provide detailed information about the function's parameters, return value, and behavior. This improves code documentation and makes it easier for other developers to understand and use the function.