### PR TITLE
Do not disable @typescript-eslint/unbound-method in ui plugin

### DIFF
--- a/dist/configs/ui.js
+++ b/dist/configs/ui.js
@@ -38,7 +38,6 @@ module.exports =
       }
     ],
     "@itwin/react-set-stage-usage": ["error", { "updater-only": false, "allow-object": true }],
-    "@typescript-eslint/unbound-method": "off",
     "react/prop-types": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
@@ -49,4 +48,3 @@ module.exports =
     }
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/eslint-plugin",
-  "version": "5.0.0-dev.2",
+  "version": "5.0.0-dev.3",
   "description": "ESLint plugin with default configuration and custom rules for iTwin.js projects",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
`@typescript-eslint/unbound-method` is a recommended rule by `itwinjs-recommened` - we shouldn't turn it off for `ui` (frontend) code.