### PR TITLE
Update TypeScript ESLint rule to warn for future errors

### DIFF
--- a/change/@itwin-eslint-plugin-699072bc-4d13-4805-a6c0-e08295be601f.json
+++ b/change/@itwin-eslint-plugin-699072bc-4d13-4805-a6c0-e08295be601f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update @typescript-eslint/restrict-template-expressions to warn with future error notice",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "anmolshres98@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/dist/configs/itwinjs-recommended.js
+++ b/dist/configs/itwinjs-recommended.js
@@ -180,7 +180,12 @@ module.exports =
     "@typescript-eslint/promise-function-async": "error",
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/restrict-plus-operands": "off",
-    "@typescript-eslint/restrict-template-expressions": "off",
+    "@typescript-eslint/restrict-template-expressions": [
+      "warn",
+      {
+        "message": "This rule will be set to error in the next major release. Please address the issue before that to avoid errors in the future."
+      }
+    ],
     "@typescript-eslint/triple-slash-reference": "error",
     "@typescript-eslint/typedef": "off",
     "@typescript-eslint/unbound-method": "error",

--- a/dist/configs/itwinjs-recommended.js
+++ b/dist/configs/itwinjs-recommended.js
@@ -183,7 +183,7 @@ module.exports =
     "@typescript-eslint/restrict-template-expressions": [
       "warn",
       {
-        "message": "This rule will be set to error in the next major release. Please address the issue before that to avoid errors in the future."
+        "message": "This rule will be set to error in the next major release."
       }
     ],
     "@typescript-eslint/triple-slash-reference": "error",


### PR DESCRIPTION
Change the configuration for `@typescript-eslint/restrict-template-expressions` to issue a warning with a notice about future error enforcement.

Closes #92

> Note: wait for response on linked issue before merging