### PR TITLE
Update @typescript-eslint/restrict-template-expressions rule to warn with no options

### DIFF
--- a/change/@itwin-eslint-plugin-0a4cd709-2393-46ec-95ff-d9a3885adab6.json
+++ b/change/@itwin-eslint-plugin-0a4cd709-2393-46ec-95ff-d9a3885adab6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update @typescript-eslint/restrict-template-expressions rule to warn with no options",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "anmolshres98@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/dist/configs/itwinjs-recommended.js
+++ b/dist/configs/itwinjs-recommended.js
@@ -180,12 +180,7 @@ module.exports =
     "@typescript-eslint/promise-function-async": "error",
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/restrict-plus-operands": "off",
-    "@typescript-eslint/restrict-template-expressions": [
-      "warn",
-      {
-        "message": "This rule will be set to error in the next major release."
-      }
-    ],
+    "@typescript-eslint/restrict-template-expressions": "warn",
     "@typescript-eslint/triple-slash-reference": "error",
     "@typescript-eslint/typedef": "off",
     "@typescript-eslint/unbound-method": "error",


### PR DESCRIPTION
`@typescript-eslint/restrict-template-expressions` does not support `message` options so running into following error during runtime:
```bash
Oops! Something went wrong! :(
│ ESLint: 9.22.0
│ Error: Key "rules": Key "@typescript-eslint/restrict-template-expressions":
│     atValue {"message":"This rule will be set to error in the next major release."} should NOT have additional properties.
│     at FlatConUnexpected property "message". Expected properties: "allowAny", "allowArray", "allowBoolean", "allowNullish", "allowNumber", "allowRegExp", "allowNever", "allow".
│     at RuleValidator.validate (/Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/eslint@9.22.0/node_modules/eslint/lib/config/rule-validator.js:180:27)
│     at new Config (/Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/eslint@9.22.0/node_modules/eslint/lib/config/config.js:233:27)
│     at [finalizeConfig] (/Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/eslint@9.22.0/node_modules/eslint/lib/config/flat-config-array.js:216:16)
│     at FlatConfigArray.getConfigWithStatus (/Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/@eslint+config-array@0.19.2/node_modules/@eslint/config-array/dist/cjs/index.cjs:1178:55)
│     at FlatConfigArray.getConfig (/Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/@eslint+config-array@0.19.2/node_modules/@eslint/config-array/dist/cjs/index.cjs:1196:15)
│     at entryFilter (/Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/eslint@9.22.0/node_modules/eslint/lib/eslint/eslint-helpers.js:282:40)
│     at async NodeHfs.<anonymous> (file:///Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/@humanfs+core@0.19.1/node_modules/@humanfs/core/src/hfs.js:574:24)
│     at async NodeHfs.<anonymous> (file:///Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/@humanfs+core@0.19.1/node_modules/@humanfs/core/src/hfs.js:604:6)
│     at async NodeHfs.walk (file:///Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/@humanfs+core@0.19.1/node_modules/@humanfs/core/src/hfs.js:614:3)
│     at async globSearch (/Users/anmol.shrestha/Documents/Bentley/spatial-editor-studio/node_modules/.pnpm/eslint@9.22.0/node_modules/eslint/lib/eslint/eslint-helpers.js:323:26)
```

This PR fixes that error. 

Tested locally on different repo.