### PR TITLE
Fix no-internal rule throwing error in 5.2.0

### DIFF
--- a/change/@itwin-eslint-plugin-ffa9d555-4c92-4c93-8bbe-3b1c58c2dd3a.json
+++ b/change/@itwin-eslint-plugin-ffa9d555-4c92-4c93-8bbe-3b1c58c2dd3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix processing of 'no-internal' rule throwing error on default import statements",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "anmolshres98@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/dist/rules/no-internal.js
+++ b/dist/rules/no-internal.js
@@ -323,7 +323,7 @@ module.exports = {
         for (const clause of tsNode.heritageClauses) {
           for (const type of clause.types) {
             const resolvedType = typeChecker.getTypeAtLocation(type.expression);
-            if (resolvedType) {
+            if (resolvedType && resolvedType.symbol) {
               checkWithParent(resolvedType.symbol.valueDeclaration, node);
             }
           }
@@ -336,7 +336,7 @@ module.exports = {
           return;
 
         const resolvedType = typeChecker.getTypeAtLocation(tsNode.right);
-        if (resolvedType) {
+        if (resolvedType && resolvedType.symbol) {
           checkWithParent(resolvedType.symbol.valueDeclaration, node);
         }
       },

--- a/dist/rules/no-internal.js
+++ b/dist/rules/no-internal.js
@@ -117,7 +117,7 @@ module.exports = {
      */
     function owningPackageIsCheckedPackage(filePath) {
       const packageList = workspace.getWorkspaces(filePath);
-      
+
       // Look through all package infos to find the one containing our packagePath
       let packageObj = packageList.find((pkg) => {
         const packageBaseDir = path.dirname(pkg.packageJson.packageJsonPath);
@@ -130,7 +130,7 @@ module.exports = {
     /**
      * Returns true if a file is within a package for which the internal tag is a violation.
      * By default `@itwin` and `@bentley` packages are included, see the `checkedPackagePatterns` option.
-     * @param declaration 
+     * @param declaration
      */
     function isCheckedFile(declaration) {
       if (!declaration)
@@ -151,7 +151,7 @@ module.exports = {
 
       if (allowWorkspaceInternal || !isWorkspaceLinkedDependency)
         return false;
-      
+
       // Else !allowWorkspaceInternal or is a local file, check package name in package.json
       return owningPackageIsCheckedPackage(fileName);
     }
@@ -219,7 +219,7 @@ module.exports = {
         checkJsDoc(declaration.parent, node);
       }
     }
-    
+
 
     return {
       CallExpression(node) {
@@ -240,7 +240,7 @@ module.exports = {
 
         for (const arg of tsCall.arguments) {
           const argType = typeChecker.getTypeAtLocation(arg);
-          if (argType) {
+          if (argType && argType.symbol) {
             checkWithParent(argType.symbol.valueDeclaration, node);
           }
         }
@@ -252,7 +252,7 @@ module.exports = {
           return;
 
         const resolvedClass = typeChecker.getTypeAtLocation(tsCall);
-        if (resolvedClass)
+        if (resolvedClass && resolvedClass.symbol)
           checkWithParent(resolvedClass.symbol.valueDeclaration, node);
 
         const resolvedConstructor = typeChecker.getResolvedSignature(tsCall);
@@ -311,7 +311,7 @@ module.exports = {
         if (!tsNode) return;
 
         const resolvedType = typeChecker.getTypeAtLocation(tsNode);
-        if (resolvedType) {
+        if (resolvedType && resolvedType.symbol) {
           checkWithParent(resolvedType.symbol.valueDeclaration, node);
         }
       },
@@ -353,7 +353,11 @@ module.exports = {
             if (specifier.type === "ImportSpecifier" || specifier.type === "ImportDefaultSpecifier" || specifier.type === "ImportNamespaceSpecifier") {
               let exportSymbol;
               if (specifier.type === "ImportDefaultSpecifier") {
-                exportSymbol = typeChecker.getAliasedSymbol(resolvedModule.exports.get("default")); 
+                const defaultExport = resolvedModule.exports.get("default") || resolvedModule.exports.get("export=");
+                // call to getAliasedSymbol() will throw if the symbol is not an alias
+                // this can happen if e.g. the default import is from a json file - `import data from "data.json";`
+                if (!defaultExport || !(defaultExport.flags & ts.SymbolFlags.Alias)) continue;
+                exportSymbol = typeChecker.getAliasedSymbol(defaultExport);
               }
               else {
                 exportSymbol = resolvedModule.exports.get(specifier.imported?.name);

--- a/tests/fixtures/no-internal/workspace-pkg-1/export-equals-module.ts
+++ b/tests/fixtures/no-internal/workspace-pkg-1/export-equals-module.ts
@@ -1,0 +1,7 @@
+// This file demonstrates the export= syntax
+const ModuleWithExportEquals = {
+  value: 42,
+  getValue: () => 42
+};
+
+export = ModuleWithExportEquals;

--- a/tests/fixtures/no-internal/workspace-pkg-1/json-import.ts
+++ b/tests/fixtures/no-internal/workspace-pkg-1/json-import.ts
@@ -1,0 +1,4 @@
+// This file is used to test importing JSON files
+import jsonData from "./test-data.json";
+
+console.log(jsonData.name);

--- a/tests/fixtures/no-internal/workspace-pkg-1/non-alias-export.ts
+++ b/tests/fixtures/no-internal/workspace-pkg-1/non-alias-export.ts
@@ -1,0 +1,4 @@
+// This file simulates other non-alias exports
+export default "not-an-alias";
+
+export const regularFunction = () => console.log("Regular function");

--- a/tests/fixtures/no-internal/workspace-pkg-1/test-data.json
+++ b/tests/fixtures/no-internal/workspace-pkg-1/test-data.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-data",
+  "value": 42,
+  "isValid": true
+}

--- a/tests/no-internal.js
+++ b/tests/no-internal.js
@@ -99,6 +99,21 @@ ruleTester.run(
         code: `import * as Local from "./local-internal"; Local.internal(); new Local.Internal();`
       },
       {
+        // JSON default import - should not throw errors
+        code: `import jsonData from "./test-data.json"; console.log(jsonData.name);`,
+        name: "JSON import should not throw"
+      },
+      {
+        // Non-alias default export - should not throw errors
+        code: `import defaultString from "./non-alias-export"; console.log(defaultString);`,
+        name: "Non-alias default export should not throw"
+      },
+      {
+        // export= module import - should not throw errors 
+        code: `import moduleWithExportEquals from "./export-equals-module"; console.log(moduleWithExportEquals.getValue());`,
+        name: "export= module import should not throw"
+      },
+      {
         // local import and package name is specified
         code: `import * as Local from "./local-internal"; Local.internal(); new Local.Internal();`,
         options: [{ "checkedPackagePatterns": ["workspace-pkg-1"] }],


### PR DESCRIPTION
Closes #100

In user's case, the processing of the rule was throwing error because the rule was trying to access an undefined value. To be specific, The following code 
```ts
import assert from "assert";
import path from "path";
```
Both lines above would throw because call to `resolvedModule.exports.get("default")` returns `undefined`. The default exports can actually be acquired via `resolvedModule.exports.get("export=")`. With more testing, there were a couple of other places an undefined value could be accidentally be attempted to be accessed so added checks to catch those.

The cases I have encountered so far are coming from processing of code that is not related to `@itwin` packages. The checks on `@itwin` packages seem to be working ok. no-internal rules are specific to itwin packages so I think it would be ok to check for undefined values and move.