### PR TITLE
Add preview tag to no-internal rule

### DIFF
--- a/change/@itwin-eslint-plugin-de5d27e9-0ff3-42fe-b712-6df8e435ee7e.json
+++ b/change/@itwin-eslint-plugin-de5d27e9-0ff3-42fe-b712-6df8e435ee7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add preview tag to no-internal rule",
+  "packageName": "@itwin/eslint-plugin",
+  "email": "66480813+paulius-valiunas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-eslint-plugin-de5d27e9-0ff3-42fe-b712-6df8e435ee7e.json
+++ b/change/@itwin-eslint-plugin-de5d27e9-0ff3-42fe-b712-6df8e435ee7e.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add preview tag to no-internal rule",
+  "comment": "Enable no-internal rule to check for preview tags",
   "packageName": "@itwin/eslint-plugin",
   "email": "66480813+paulius-valiunas@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/dist/rules/no-internal.js
+++ b/dist/rules/no-internal.js
@@ -53,7 +53,7 @@ module.exports = {
             uniqueItems: true,
             items: {
               type: "string",
-              enum: ["public", "beta", "alpha", "internal"]
+              enum: ["public", "preview", "beta", "alpha", "internal"]
             }
           },
           checkedPackagePatterns: {


### PR DESCRIPTION
Now that we have a preview tag, the no-internal rule should also support checking for it (only if the config is set accordingly)