### PR TITLE
Change deprecation rule to add 3 month support period to preview elements

### DIFF
--- a/dist/rules/require-version-in-deprecation.js
+++ b/dist/rules/require-version-in-deprecation.js
@@ -27,6 +27,8 @@ const deprecatedCommentRegex = new RegExp(
   "gdu",
 );
 
+const previewRegex = new RegExp("@preview");
+
 const validDescriptionRegex = /^[\w\]`]/;
 
 const messages = {
@@ -84,102 +86,159 @@ module.exports = {
     ],
   },
   create(context) {
-    return {
-      Program(program) {
+    let sourceCode = context.sourceCode;
+
+    function hasPreviewComment(node) {
+      const comments = sourceCode.getCommentsBefore(node);
+      return comments.some((comment) => previewRegex.test(comment.value));
+    }
+
+    /**
+     * Apply lint rule on the comments of provided node
+     * @param {Rule.Node} mainNode
+     */
+    function lintCommentsOfNode(mainNode) {
+      for (const comment of sourceCode.getCommentsBefore(mainNode)) {
         let regexMatch;
-        for (const comment of program.comments ?? []) {
-          let found = 0;
-          /** @type {Rule.Node} */
-          // @ts-expect-error -- comments are not considered nodes but this still works
-          const node = comment;
-          /** @type {Scope.Scope["block"]} */
-          while ((regexMatch = deprecatedCommentRegex.exec(comment.value))) {
-            const match = regexMatch;
-            if (found === 1) {
-              context.report({
-                node,
-                messageId: messageIds.doubleDeprecation,
-              });
-            }
-            found++;
-            if (!match.groups?.description) {
-              context.report({
-                node,
-                messageId: messageIds.noDescription,
-              });
-              continue; // no point in applying any fixes after this - the description will have to be added manually anyway.
-            }
-
-            let noVersion = false;
-            let addDate = false;
-            let oldDate = false;
-            let addSeparator = false;
-            let removeSeparator = false;
-            let badDescription = false;
-            if (!match.groups?.version) {
-              // the version is missing
-              if (context.options[0]?.addVersion || match.groups?.when) {
-                // either the options require having a version, or the deprecation date is already there, in both cases the version should also be there.
-                noVersion = true;
-              }
-            }
-
-            if (match.groups?.version?.includes("x")) {
-              context.report({
-                node,
-                messageId: messageIds.badVersion,
-              });
-            }
-
-            const now = DateTime.now();
-            const currentDate = now.toFormat("yyyy-MM-dd");
-            const targetDate = now.plus({ year: 1 }).toFormat("yyyy-MM-dd");
-
-            if (context.options[0]?.addVersion && !match.groups?.when) {
-              // add date
-              addDate = true;
-            }
-
-            if (context.options[0]?.removeOldDates && match.groups?.date && match.groups.date < currentDate) {
-              // remove old date
-              oldDate = true;
-            }
-
-            if (match.groups?.description && !validDescriptionRegex.test(match.groups.description)) badDescription = true;
-
-            if ((match.groups?.version || match.groups?.when) && !match.groups?.separator && match.groups?.description) addSeparator = true;
-            else if (!(match.groups?.version || match.groups?.when) && match.groups?.separator && match.groups?.description) removeSeparator = true;
-
-            const oldDescription = match.groups?.description?.trimStart() ?? "";
-            const newDescription = firstUpper(oldDescription.replace(/^-\s*/, ""));
-            const newComment =
-              comment.value.substring(0, match.index) +
-              "@deprecated" +
-              (noVersion && context.options[0]?.addVersion
-                ? ` in ${context.options[0].addVersion}`
-                : match.groups?.version
-                ? ` in ${match.groups.version}`
-                : "") +
-              (addDate
-                ? ` - ${regexParts.notUntil} ${targetDate}`
-                : oldDate
-                ? ` - ${regexParts.expired}`
-                : match.groups?.when
-                ? ` - ${match.groups.when}`
-                : "") +
-              (addDate || oldDate || match.groups?.when || noVersion || match.groups?.version ? "." : "") +
-              ` ${newDescription}` +
-              comment.value.substring(match.index + match[0].length);
-
-            /** @param {Rule.RuleFixer} fixer */
-            const fix = newComment !== comment.value ? (fixer) => wrapComment(fixer, comment, newComment) : undefined;
-            if (noVersion) context.report({ node, messageId: messageIds.noVersion, fix });
-            if (addDate) context.report({ node, messageId: messageIds.noDate, fix });
-            if (oldDate) context.report({ node, messageId: messageIds.oldDate, fix });
-            if (addSeparator || removeSeparator) context.report({ node, messageId: messageIds.noSeparator, fix });
-            if (badDescription) context.report({ node, messageId: messageIds.badDescription, fix });
+        let found = 0;
+        /** @type {Rule.Node} */
+        // @ts-expect-error -- comments are not considered nodes but this still works
+        const node = comment;
+        /** @type {Scope.Scope["block"]} */
+        while ((regexMatch = deprecatedCommentRegex.exec(comment.value))) {
+          const match = regexMatch;
+          if (found === 1) {
+            context.report({
+              node,
+              messageId: messageIds.doubleDeprecation,
+            });
           }
+          found++;
+          if (!match.groups?.description) {
+            context.report({
+              node,
+              messageId: messageIds.noDescription,
+            });
+            continue; // no point in applying any fixes after this - the description will have to be added manually anyway.
+          }
+
+          let noVersion = false;
+          let addDate = false;
+          let oldDate = false;
+          let addSeparator = false;
+          let removeSeparator = false;
+          let badDescription = false;
+          let isPreview = false;
+          if (!match.groups?.version) {
+            // the version is missing
+            if (context.options[0]?.addVersion || match.groups?.when) {
+              // either the options require having a version, or the deprecation date is already there, in both cases the version should also be there.
+              noVersion = true;
+            }
+          }
+
+          if (match.groups?.version?.includes("x")) {
+            context.report({
+              node,
+              messageId: messageIds.badVersion,
+            });
+          }
+
+          const ancestors = sourceCode.getAncestors(mainNode);
+          isPreview = ancestors.some((ancestor) => hasPreviewComment(ancestor));
+
+          const now = DateTime.now();
+          const currentDate = now.toFormat("yyyy-MM-dd");
+          let targetDate;
+          if (isPreview) {
+            targetDate = now.plus({ month: 3 }).toFormat("yyyy-MM-dd");
+          } else {
+            targetDate = now.plus({ year: 1 }).toFormat("yyyy-MM-dd");
+          }
+
+          if (context.options[0]?.addVersion && !match.groups?.when) {
+            // add date
+            addDate = true;
+          }
+
+          if (context.options[0]?.removeOldDates && match.groups?.date && match.groups.date < currentDate) {
+            // remove old date
+            oldDate = true;
+          }
+
+          if (match.groups?.description && !validDescriptionRegex.test(match.groups.description)) badDescription = true;
+
+          if ((match.groups?.version || match.groups?.when) && !match.groups?.separator && match.groups?.description) addSeparator = true;
+          else if (!(match.groups?.version || match.groups?.when) && match.groups?.separator && match.groups?.description) removeSeparator = true;
+
+          const oldDescription = match.groups?.description?.trimStart() ?? "";
+          const newDescription = firstUpper(oldDescription.replace(/^-\s*/, ""));
+          const newComment =
+            comment.value.substring(0, match.index) +
+            "@deprecated" +
+            (noVersion && context.options[0]?.addVersion
+              ? ` in ${context.options[0].addVersion}`
+              : match.groups?.version
+              ? ` in ${match.groups.version}`
+              : "") +
+            (addDate
+              ? ` - ${regexParts.notUntil} ${targetDate}`
+              : oldDate
+              ? ` - ${regexParts.expired}`
+              : match.groups?.when
+              ? ` - ${match.groups.when}`
+              : "") +
+            (addDate || oldDate || match.groups?.when || noVersion || match.groups?.version ? "." : "") +
+            ` ${newDescription}` +
+            comment.value.substring(match.index + match[0].length);
+
+          /** @param {Rule.RuleFixer} fixer */
+          const fix = newComment !== comment.value ? (fixer) => wrapComment(fixer, comment, newComment) : undefined;
+          if (noVersion) context.report({ node, messageId: messageIds.noVersion, fix });
+          if (addDate) context.report({ node, messageId: messageIds.noDate, fix });
+          if (oldDate) context.report({ node, messageId: messageIds.oldDate, fix });
+          if (addSeparator || removeSeparator) context.report({ node, messageId: messageIds.noSeparator, fix });
+          if (badDescription) context.report({ node, messageId: messageIds.badDescription, fix });
         }
+      }
+    }
+
+    return {
+      ClassDeclaration(node) {
+        lintCommentsOfNode(node);
+      },
+      FunctionDeclaration(node) {
+        lintCommentsOfNode(node);
+      },
+      MethodDefinition(node) {
+        lintCommentsOfNode(node);
+      },
+      TSEnumDeclaration(node) {
+        lintCommentsOfNode(node);
+      },
+      TSInterfaceDeclaration(node) {
+        lintCommentsOfNode(node);
+      },
+      PropertyDefinition(node) {
+        lintCommentsOfNode(node);
+      },
+      TSEnumMember(node) {
+        lintCommentsOfNode(node);
+      },
+      TSPropertySignature(node) {
+        lintCommentsOfNode(node);
+      },
+      TSTypeAliasDeclaration(node) {
+        lintCommentsOfNode(node);
+      },
+      ExportNamedDeclaration(node) {
+        lintCommentsOfNode(node);
+      },
+      VariableDeclaration(node) {
+        lintCommentsOfNode(node);
+      },
+      TSModuleDeclaration(node) {
+        lintCommentsOfNode(node);
       },
     };
   },

--- a/dist/rules/require-version-in-deprecation.js
+++ b/dist/rules/require-version-in-deprecation.js
@@ -144,8 +144,14 @@ module.exports = {
             });
           }
 
-          const ancestors = sourceCode.getAncestors(mainNode);
-          isPreview = ancestors.some((ancestor) => hasPreviewComment(ancestor));
+          if (context.options[0]?.addVersion && !match.groups?.when) {
+            // add date
+            addDate = true;
+
+            // check for parents with @preview tag only if needed to add the date
+            const ancestors = sourceCode.getAncestors(mainNode);
+            isPreview = ancestors.some((ancestor) => hasPreviewComment(ancestor));
+          }
 
           const now = DateTime.now();
           const currentDate = now.toFormat("yyyy-MM-dd");
@@ -154,11 +160,6 @@ module.exports = {
             targetDate = now.plus({ month: 3 }).toFormat("yyyy-MM-dd");
           } else {
             targetDate = now.plus({ year: 1 }).toFormat("yyyy-MM-dd");
-          }
-
-          if (context.options[0]?.addVersion && !match.groups?.when) {
-            // add date
-            addDate = true;
           }
 
           if (context.options[0]?.removeOldDates && match.groups?.date && match.groups.date < currentDate) {

--- a/tests/require-version-in-deprecation.js
+++ b/tests/require-version-in-deprecation.js
@@ -27,81 +27,132 @@ ruleTester.run(
   supportSkippedAndOnlyInTests({
     valid: [
       {
-        code: `/**
-      * @beta
-      * @deprecated in 3.0. Use XYZ instead, see https://www.google.com/ for more details.
-      */`,
+        code: `
+        /**
+        * @beta
+        * @deprecated in 3.0. Use XYZ instead, see https://www.google.com/ for more details.
+        */
+        enum ModelType {}`,
       },
       {
-        code: `/**
+        code: `
+        /**
         * @deprecated in 3.0. Use XYZ instead
         * @beta
-        */`,
+        */
+        interface ModelType {}`,
       },
-      { code: `// @deprecated in 3.6. Use XYZ instead.` },
-      { code: `/* @deprecated in 12.0. Use xyz instead. */` },
       {
-        code: `// @deprecated in 2.19.  Use xyz instead
+        code: `
+        class A {
+          // @deprecated in 3.6. Use XYZ instead.
+          public B: int;
+        }`,
+      },
+      {
+        code: `
+        export enum ModelTypes {
+          /* @deprecated in 12.0. Use xyz instead. */
+          Test = 1,
+        }`,
+      },
+      {
+        code: `
+        // @deprecated in 2.19.  Use xyz instead
         function canWeUseFunctions() {}`,
       },
       {
-        code: `// @deprecated in 3.6. Use xyz instead.
+        code: `
+        // @deprecated in 3.6. Use xyz instead.
         class canWeUseAClass {};`,
       },
       {
-        code: `/* @deprecated in 2.0. Use XYZ instead */
+        code: `
+        /* @deprecated in 2.0. Use XYZ instead */
         let canWeUseArrowFunction = () => {};`,
       },
       {
-        code: `/**
+        code: `
+        /**
         * @deprecated in 3.0. Please use XYZ.
         */
         export interface canWeUseInterface {}`,
       },
       {
-        code: `/* @deprecated in 2.0. Use xyz instead. */
+        code: `
+        /* @deprecated in 2.0. Use xyz instead. */
         namespace canWeUseNamespaces {}`,
       },
       {
-        code: `// @deprecated in 3.6. Use XYZ instead.
+        code: `
+        // @deprecated in 3.6. Use XYZ instead.
         export enum canWeUseEnum {}`,
       },
       {
         code: `
         interface BackendHubAccess {
-          /**
-           * download a v1 checkpoint
-           * @deprecated in 3.0. Here's a description.
-           * @internal
-           */
-          downloadV1Checkpoint: (arg: CheckpointArg) => Promise<ChangesetIndexAndId>;
+        /**
+         * download a v1 checkpoint
+         * @deprecated in 3.0. Here's a description.
+         * @internal
+         */
+        downloadV1Checkpoint: (arg: CheckpointArg) => Promise<ChangesetIndexAndId>;
         }
         `,
       },
-      { code: `// @deprecated in 2.0. Use [[InternalDocRef]] instead` },
-      { code: `/** @deprecated in 3.0. Use [ExternalDocRef]($package) instead */` },
-      { code: `/** @deprecated in 2.1 - will not be removed until after 2022-01-01. Use [[methodB]] instead */` },
-      { code: `/** @deprecated Use [[methodB]] instead */` },
-      { code: `/** @deprecated in 3.2. Use [[methodB]] instead */` },
-      { code: `/** @deprecated in 3.2. use [[methodB]] instead */` },
+      {
+        code: `
+        // @deprecated in 2.0. Use [[InternalDocRef]] instead
+        export function TestFunc(){}`,
+      },
+      {
+        code: `
+        /** @deprecated in 3.0. Use [ExternalDocRef]($package) instead */
+        export type testType = () => {};`,
+      },
+      {
+        code: `
+        class ConnectionHandler {
+          /** @deprecated in 2.1 - will not be removed until after 2022-01-01. Use [[methodB]] instead */
+          constructor() {};
+        }`,
+      },
+      {
+        code: `
+        /** @deprecated Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
+      {
+        code: `
+        /** @deprecated in 3.2. Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
+      {
+        code: `
+        /** @deprecated in 3.2. use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
     ],
     invalid: [
       {
         code: `/**
         * @beta
         * @deprecated
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noDescription]),
       },
       {
         code: `/**
         * @deprecated Use [[A]] instead
         * @deprecated Use [[B]] instead
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.doubleDeprecation]),
       },
       {
-        code: `// @deprecated in 3.x.x.x. Use [[A]]`,
+        code: `// @deprecated in 3.x.x.x. Use [[A]]
+        enum TestEnum {}`,
         // The error can be a bit misleading. Since versions can only have 3 parts, the rule assumes that the last `.x` is part of the description.
         // However, it does give the developer a hint about what exactly is going wrong by splitting the version and inserting a space.
         errors: messageIds([rule.messageIds.noSeparator, rule.messageIds.badDescription]),
@@ -111,39 +162,52 @@ ruleTester.run(
         skip: true,
       },
       {
-        code: `/** @deprecated. Use [[methodB]] instead */`,
+        code: `/** @deprecated. Use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noSeparator]),
-        output: `/** @deprecated Use [[methodB]] instead */`,
+        output: `/** @deprecated Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated in 3.2 use [[methodB]] instead */`,
+        code: `/** @deprecated in 3.2 use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noSeparator]),
-        output: `/** @deprecated in 3.2. Use [[methodB]] instead */`,
+        output: `/** @deprecated in 3.2. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated in 3.2 - use [[methodB]] instead */`,
+        code: `/** @deprecated in 3.2 - use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noSeparator, rule.messageIds.badDescription]),
-        output: `/** @deprecated in 3.2. Use [[methodB]] instead */`,
+        output: `/** @deprecated in 3.2. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated - will not be removed until after 2022-01-01. Use [[methodB]] instead */`,
+        code: `/** @deprecated - will not be removed until after 2022-01-01. Use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noVersion]),
       },
       {
         code: `/**
-      * @beta
-      * @deprecated in 3.x. Use XYZ instead, see https://www.google.com/ for more details.
-      */`,
+        * @beta
+        * @deprecated in 3.x. Use XYZ instead, see https://www.google.com/ for more details.
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.badVersion]),
       },
       {
         code: `/**
         * @deprecated in 3.x. Use XYZ instead
         * @beta
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.badVersion]),
       },
-      { code: `/* @deprecated in 12.x. Use xyz instead. */`, errors: messageIds([rule.messageIds.badVersion]) },
+      {
+        code: `/* @deprecated in 12.x. Use xyz instead. */
+        enum TestEnum {}`,
+        errors: messageIds([rule.messageIds.badVersion]),
+      },
       {
         code: `/* @deprecated in 2.x. Use XYZ instead */
         let canWeUseArrowFunction = () => {};`,
@@ -183,10 +247,22 @@ ruleTester.run(
   rule,
   supportSkippedAndOnlyInTests({
     valid: [
-      { code: `/** @deprecated in 2.1 - will not be removed until after 3022-01-01. Use [[methodB]] instead */` },
-      { code: `/** @deprecated Use [[methodB]] instead */` },
-      { code: `/** @deprecated in 3.2. Use [[methodB]] instead */` },
-      { code: `/** @deprecated in 2.1 - might be removed in next major version. Use [[methodB]] instead */` },
+      {
+        code: `/** @deprecated in 2.1 - will not be removed until after 3022-01-01. Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
+      {
+        code: `/** @deprecated Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
+      {
+        code: `/** @deprecated in 3.2. Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
+      {
+        code: `/** @deprecated in 2.1 - might be removed in next major version. Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
     ].map((testCase) => ({
       ...testCase,
       options: [{ removeOldDates: true }],
@@ -196,47 +272,61 @@ ruleTester.run(
         code: `/**
         * @beta
         * @deprecated
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noDescription]),
       },
       {
         code: `/**
         * @deprecated Use [[A]] instead
         * @deprecated Use [[B]] instead
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.doubleDeprecation]),
       },
       {
-        code: `/** @deprecated. Use [[methodB]] instead */`,
+        code: `/** @deprecated. Use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noSeparator]),
-        output: `/** @deprecated Use [[methodB]] instead */`,
+        output: `/** @deprecated Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated in 3.2 use [[methodB]] instead */`,
+        code: `/** @deprecated in 3.2 use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noSeparator]),
-        output: `/** @deprecated in 3.2. Use [[methodB]] instead */`,
+        output: `/** @deprecated in 3.2. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated in 3.2 - use [[methodB]] instead */`,
+        code: `/** @deprecated in 3.2 - use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noSeparator, rule.messageIds.badDescription]),
-        output: `/** @deprecated in 3.2. Use [[methodB]] instead */`,
+        output: `/** @deprecated in 3.2. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated in 2.1 - will not be removed until after 2022-01-01. Use [[methodB]] instead */`,
+        code: `/** @deprecated in 2.1 - will not be removed until after 2022-01-01. Use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.oldDate]),
-        output: `/** @deprecated in 2.1 - might be removed in next major version. Use [[methodB]] instead */`,
+        output: `/** @deprecated in 2.1 - might be removed in next major version. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated - will not be removed until after 2022-01-01. Use [[methodB]] instead */`,
+        code: `/** @deprecated - will not be removed until after 2022-01-01. Use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noVersion, rule.messageIds.oldDate]),
-        output: `/** @deprecated - might be removed in next major version. Use [[methodB]] instead */`,
+        output: `/** @deprecated - might be removed in next major version. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated - might be removed in next major version. Use [[methodB]] instead */`,
+        code: `/** @deprecated - might be removed in next major version. Use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noVersion]),
       },
       {
-        code: `/** @deprecated - will not be removed until after 3022-01-01. Use [[methodB]] instead */`,
+        code: `/** @deprecated - will not be removed until after 3022-01-01. Use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noVersion]),
       },
     ].map((testCase) => ({ ...testCase, options: [{ removeOldDates: true }] })),
@@ -250,14 +340,25 @@ ruleTester.run(
   rule,
   supportSkippedAndOnlyInTests({
     valid: [
-      { code: `/** @deprecated in 2.1 - will not be removed until after 3022-01-01. Use [[methodB]] instead */` },
-      { code: `/** @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[methodB]] instead */` },
-      { code: `/** @deprecated in 3.2 - will not be removed until after ${targetDate}. Use [[methodB]] instead */` },
       {
-        code: `/** 
-                * @deprecated in 3.0 - will not be removed until after ${targetDate}. Use [[B]]
-                * @public
-                */`,
+        code: `/** @deprecated in 2.1 - will not be removed until after 3022-01-01. Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
+      {
+        code: `/** @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
+      {
+        code: `/** @deprecated in 3.2 - will not be removed until after ${targetDate}. Use [[methodB]] instead */
+        enum TestEnum {}`,
+      },
+      {
+        code: `
+        /** 
+        * @deprecated in 3.0 - will not be removed until after ${targetDate}. Use [[B]]
+        * @public
+        */
+        enum TestEnum {}`,
       },
     ].map((testCase) => ({
       ...testCase,
@@ -268,14 +369,16 @@ ruleTester.run(
         code: `/**
         * @beta
         * @deprecated
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noDescription]),
       },
       {
         code: `/**
         * @deprecated Use [[A]] instead
         * @deprecated Use [[B]] instead
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([
           rule.messageIds.noVersion,
           rule.messageIds.noDate,
@@ -286,51 +389,136 @@ ruleTester.run(
         output: `/**
         * @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[A]] instead
         * @deprecated Use [[B]] instead
-        */`,
+        */
+        enum TestEnum {}`,
       },
       {
         code: `/**
         * @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[A]] instead
         * @deprecated Use [[B]] instead
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.doubleDeprecation, rule.messageIds.noVersion, rule.messageIds.noDate]),
         output: `/**
         * @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[A]] instead
         * @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[B]] instead
-        */`,
+        */
+        enum TestEnum {}`,
       },
       {
         code: `/**
         * @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[A]] instead
         * @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[B]] instead
-        */`,
+        */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.doubleDeprecation]),
       },
       {
-        code: `/** @deprecated. Use [[methodB]] instead */`,
+        code: `/** @deprecated. Use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noVersion, rule.messageIds.noDate, rule.messageIds.noSeparator]),
-        output: `/** @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[methodB]] instead */`,
+        output: `/** @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated in 10.0 use [[methodB]] instead */`,
+        code: `/** @deprecated in 10.0 use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noDate, rule.messageIds.noSeparator]),
-        output: `/** @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[methodB]] instead */`,
+        output: `/** @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
-        code: `/** @deprecated in 10.0 - use [[methodB]] instead */`,
+        code: `/** @deprecated in 10.0 - use [[methodB]] instead */
+        enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noDate, rule.messageIds.noSeparator, rule.messageIds.badDescription]),
-        output: `/** @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[methodB]] instead */`,
+        output: `/** @deprecated in 10.0 - will not be removed until after ${targetDate}. Use [[methodB]] instead */
+        enum TestEnum {}`,
       },
       {
         code: `/** 
                 * @deprecated in 3.0 - use [[B]]
                 * @public
-                */`,
+                */
+                enum TestEnum {}`,
         errors: messageIds([rule.messageIds.noDate, rule.messageIds.noSeparator, rule.messageIds.badDescription]),
         output: `/** 
                 * @deprecated in 3.0 - will not be removed until after ${targetDate}. Use [[B]]
                 * @public
-                */`,
+                */
+                enum TestEnum {}`,
+      },
+    ].map((testCase) => ({ ...testCase, options: [{ addVersion: "10.0" }] })),
+  }),
+);
+
+const previewTargetDate = DateTime.now().plus({ month: 3 }).toFormat("yyyy-MM-dd");
+
+ruleTester.run(
+  "require-version-in-deprecation test @preview tag",
+  rule,
+  supportSkippedAndOnlyInTests({
+    valid: [
+      {
+        code: `
+        /* @preview */
+        class ConnectionHandler {
+          /*
+          * Start a connection with the server
+          * @deprecated in 7.3.2 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          */
+          public static start(): void {};
+        }`,
+      },
+      {
+        code: `
+        // @preview
+        class A {
+          // @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          public B: int;
+        }`,
+      },
+      {
+        code: `
+        // @preview
+        export enum ModelTypes {
+          // @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          Test = 1,
+        }`,
+      },
+      {
+        code: `
+        // @preview
+        interface ModelType {
+          // @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          test: string;
+        }`,
+      },
+      {
+        code: `
+        // @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+        // @preview
+        export type testType = () => {};`,
+      },
+      {
+        code: `
+        /**
+         * @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+         * @preview
+         */
+        export type testType = () => {};`,
+      },
+    ].map((testCase) => ({
+      ...testCase,
+      options: [{ addVersion: "10.0" }],
+    })),
+    invalid: [
+      {
+        code: `/**
+        * @beta
+        * @deprecated
+        */
+        enum TestEnum {}`,
+        errors: messageIds([rule.messageIds.noDescription]),
       },
     ].map((testCase) => ({ ...testCase, options: [{ addVersion: "10.0" }] })),
   }),

--- a/tests/require-version-in-deprecation.js
+++ b/tests/require-version-in-deprecation.js
@@ -473,7 +473,7 @@ ruleTester.run(
         code: `
         // @preview
         class A {
-          // @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          // @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
           public B: int;
         }`,
       },
@@ -481,7 +481,7 @@ ruleTester.run(
         code: `
         // @preview
         export enum ModelTypes {
-          // @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          // @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
           Test = 1,
         }`,
       },
@@ -489,23 +489,23 @@ ruleTester.run(
         code: `
         // @preview
         interface ModelType {
-          // @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          // @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
           test: string;
         }`,
       },
       {
         code: `
-        // @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+        // @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
         // @preview
         export type testType = () => {};`,
       },
       {
         code: `
         /**
-         * @deprecated in 1.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+         * @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
          * @preview
          */
-        export type testType = () => {};`,
+        type testType = () => {};`,
       },
     ].map((testCase) => ({
       ...testCase,
@@ -513,12 +513,75 @@ ruleTester.run(
     })),
     invalid: [
       {
-        code: `/**
-        * @beta
-        * @deprecated
-        */
-        enum TestEnum {}`,
-        errors: messageIds([rule.messageIds.noDescription]),
+        code: `
+        // @preview
+        class A {
+          // @deprecated in 10.0.0. Use [[B]]
+          public B: int;
+        }`,
+        errors: messageIds([rule.messageIds.noDate]),
+        output: `
+        // @preview
+        class A {
+          // @deprecated in 10.0.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          public B: int;
+        }`,
+      },
+      {
+        code: `
+        // @preview
+        export enum ModelTypes {
+          // @deprecated in 10.0. Use [[B]]
+          Test = 1,
+        }`,
+        errors: messageIds([rule.messageIds.noDate]),
+        output: `
+        // @preview
+        export enum ModelTypes {
+          // @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          Test = 1,
+        }`,
+      },
+      {
+        code: `
+        // @preview
+        interface ModelType {
+          // @deprecated in 10.0. Use [[B]]
+          test: string;
+        }`,
+        errors: messageIds([rule.messageIds.noDate]),
+        output: `
+        // @preview
+        interface ModelType {
+          // @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+          test: string;
+        }`,
+      },
+      {
+        code: `
+        // @deprecated in 10.0. Use [[B]]
+        // @preview
+        export type testType = () => {};`,
+        errors: messageIds([rule.messageIds.noDate]),
+        output: `
+        // @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+        // @preview
+        export type testType = () => {};`,
+      },
+      {
+        code: `
+        /**
+         * @deprecated in 10.0. Use [[B]]
+         * @preview
+         */
+        type testType = () => {};`,
+        errors: messageIds([rule.messageIds.noDate]),
+        output: `
+        /**
+         * @deprecated in 10.0 - will not be removed until after ${previewTargetDate}. Use [[B]]
+         * @preview
+         */
+        type testType = () => {};`,
       },
     ].map((testCase) => ({ ...testCase, options: [{ addVersion: "10.0" }] })),
   }),


### PR DESCRIPTION
`@preview` tag means that the support period for that element upon deprecation is 3 months. Since `@preview` tag is inherited, any nested deprecated elements should also have 3 month support period instead of 1 year.

Previously the deprecation rule did not account for `@preview` tag. Now if a date is missing (`addDate = true`), then we check whether any parent nodes had a `@preview` tag.

Had to make the rule run on `nodes` instead of just going through `program.comments` because that way we can go through parent nodes.